### PR TITLE
fix: fix bugs about vector's db doesn't suppport blank params

### DIFF
--- a/dify_rag/extractor/html_extractor.py
+++ b/dify_rag/extractor/html_extractor.py
@@ -101,4 +101,5 @@ class HtmlExtractor(BaseExtractor):
                         table, self._title_convert_to_markdown
                     )
                 )
-        return docs
+
+        return utils.serialization_documents_metadata(docs) 

--- a/dify_rag/extractor/markdown_extractor.py
+++ b/dify_rag/extractor/markdown_extractor.py
@@ -76,7 +76,7 @@ class MarkdownExtractor(BaseExtractor):
                 )
             )
 
-        return documents
+        return utils.serialization_documents_metadata(documents) 
 
     @staticmethod
     def update_hierarchy_headers(

--- a/dify_rag/extractor/pdf_extractor.py
+++ b/dify_rag/extractor/pdf_extractor.py
@@ -9,7 +9,10 @@ import pymupdf
 from dify_rag.extractor.extractor_base import BaseExtractor
 from dify_rag.extractor.pdf import constants, pdf_helper
 from dify_rag.extractor.pdf.toc import generate_toc
-from dify_rag.extractor.utils import fix_error_pdf_content
+from dify_rag.extractor.utils import (
+    fix_error_pdf_content,
+    serialization_documents_metadata,
+)
 from dify_rag.models.document import Document
 
 
@@ -73,4 +76,4 @@ class PdfExtractor(BaseExtractor):
             documents = [Document(page_content=content)]
 
         doc.close()
-        return documents
+        return serialization_documents_metadata(documents)

--- a/dify_rag/extractor/utils.py
+++ b/dify_rag/extractor/utils.py
@@ -1,7 +1,10 @@
 import re
 from functools import lru_cache
+from typing import List
 
 import jieba
+
+from dify_rag.models.document import Document
 
 common_characters = set(
     "＞、abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,!?;:'\"-，。！？；：”“‘’\n\t+-*\\/·[]{}【】()（）@#$%^&<>《》`~］′＜～‐='"
@@ -252,3 +255,10 @@ def fix_error_pdf_content(text: str):
     text = re.sub(r"(?<![\u4e00-\u9fa5])郁|郁(?![\u4e00-\u9fa5])|郁(?=期)", "Ⅳ", text)
 
     return text.replace("\n", "")
+
+
+def serialization_documents_metadata(documents: List[Document]):
+    for doc in documents:
+        # Only processes titles of metadata then
+        doc.metadata["titles"] = "\n".join(doc.metadata.get("titles", []))
+    return documents


### PR DESCRIPTION
vector databases do not support lists, modify the data type of the metadata's titles field
![image](https://github.com/user-attachments/assets/721f68dd-cfe4-4663-ab01-6f49138aadad)
